### PR TITLE
fix: don't send impressions twice

### DIFF
--- a/lib/players.js
+++ b/lib/players.js
@@ -34,7 +34,9 @@ module.exports = function (auth, baseUrl, opts) {
           if(_.isEmpty(campaigns)){
             return Promise.resolve([{statusCode: 400}]);
           }
-          return Promise.all(_.map(campaigns, function(impressions, campaignId){
+          return Promise.all(Object.keys(campaigns).map(function(campaignId){
+            var impressions = campaigns[campaignId];
+
             impressions.campaignId = campaignId;
             console.log("MAPPING:", impressions)
             return requestAsync({


### PR DESCRIPTION
For some strange reason that I can't understand we end up in the `_.map` loop twice when running this on node but not in the browser (using the same version of lodash).

```js
          var campaigns = {
            '5def747c9e986d1d5f5f18b9': {
              impressions: [ [Object] ],
              mediaId: '5deec04c18797e00194e617c'
            }
          };

          if(_.isEmpty(campaigns)){
            return Promise.resolve([{statusCode: 400}]);
          }
          console.log('outside');                                   // prints once
          return Promise.all(_.map(campaigns, function(impressions, campaignId){
            console.log('inside');                                   // prints twice
            impressions.campaignId = campaignId;
            console.log("MAPPING:", impressions)
            return requestAsync({
            ...
```

A new release fo this module is required